### PR TITLE
Andymck/use peerbook in libp2p

### DIFF
--- a/src/libp2p_peer.erl
+++ b/src/libp2p_peer.erl
@@ -139,7 +139,6 @@ is_similar(Target=#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{timestamp=TargetTi
         andalso nat_type(Target) == nat_type(Other)
         andalso network_id(Target) == network_id(Other)
         andalso sets:from_list(listen_addrs(Target)) == sets:from_list(listen_addrs(Other))
-        andalso sets:from_list(connected_peers(Target)) == sets:from_list(connected_peers(Other))
         andalso TimestampSimilar.
 
 %% @doc Returns the declared network id for the peer, if any

--- a/src/libp2p_peer.erl
+++ b/src/libp2p_peer.erl
@@ -223,7 +223,7 @@ encode(Msg=#libp2p_signed_peer_pb{}, false) ->
 %% @doc Encodes a given list of peer into a binary form. Since
 %% encoding lists is primarily used for gossipping peers around, this
 %% strips metadata from the peers as part of encoding.
--spec encode_list([peer()]) -> [binary()].
+-spec encode_list([libp2p_peer:peer()]) -> binary().
 encode_list(List) ->
     StrippedList = [metadata_set(P, []) || P <- List],
     libp2p_peer_pb:encode_msg(#libp2p_peer_list_pb{peers=StrippedList}).

--- a/src/libp2p_peer.erl
+++ b/src/libp2p_peer.erl
@@ -139,6 +139,7 @@ is_similar(Target=#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{timestamp=TargetTi
         andalso nat_type(Target) == nat_type(Other)
         andalso network_id(Target) == network_id(Other)
         andalso sets:from_list(listen_addrs(Target)) == sets:from_list(listen_addrs(Other))
+        andalso sets:from_list(connected_peers(Target)) == sets:from_list(connected_peers(Other))
         andalso TimestampSimilar.
 
 %% @doc Returns the declared network id for the peer, if any
@@ -259,11 +260,15 @@ verify(Msg=#libp2p_signed_peer_pb{peer=Peer0=#libp2p_peer_pb{signed_metadata=MD}
 sign_peer(Peer0 = #libp2p_peer_pb{signed_metadata=MD}, SigFun) ->
     Peer = Peer0#libp2p_peer_pb{signed_metadata=lists:usort(MD)},
     EncodedPeer = libp2p_peer_pb:encode_msg(Peer),
-    case SigFun(EncodedPeer) of
+    try SigFun(EncodedPeer) of
         {error, Error} ->
             {error, Error};
         Signature ->
             {ok, #libp2p_signed_peer_pb{peer=Peer, signature=Signature}}
+    catch C:E ->
+            %% probably a timeout
+            lager:info("signing peer failed: ~p:~p", [C, E]),
+            {error, sign_failure}
     end.
 
 encode_map(Map) ->

--- a/src/libp2p_peerbook.erl
+++ b/src/libp2p_peerbook.erl
@@ -117,7 +117,6 @@ put(Handle=#peerbook{pubkey_bin=ThisPeerId}, NewPeer, Prevalidated) ->
 %% may not be available when requested again.
 -spec get(peerbook(), libp2p_crypto:pubkey_bin()) -> {ok, libp2p_peer:peer()} | {error, term()}.
 get(#peerbook{pubkey_bin=ThisPeerId, seed_node=SeedNode}=Handle, ID) ->
-    %% TODO - old peerbook checked for seednode, do we need same here?
     case unsafe_fetch_peer(ID, Handle) of
         {error, not_found} when ID == ThisPeerId, SeedNode == false  ->
             gen_server:call(peerbook_pid(Handle), update_this_peer, infinity),

--- a/src/libp2p_peerbook.erl
+++ b/src/libp2p_peerbook.erl
@@ -352,7 +352,7 @@ init(Opts = #{ sig_fun := SigFun,
 
     lager:debug("*** starting peerbook with opts ~p",[Opts]),
     RegisterCallBackFun = maps:get(register_callback, Opts, undefined),
-    RegisterName = maps:get(register_name, Opts, undefined),
+    RegisterRef = maps:get(register_ref, Opts, undefined),
 
 
     erlang:process_flag(trap_exit, true),
@@ -400,11 +400,12 @@ init(Opts = #{ sig_fun := SigFun,
                                        network_id = NetworkID,
                                        stale_time = StaleTime},
                     ets:insert(TID, {{?PEERBOOK_SERVICE, handle}, Handle}),
-                    ok = maybe_do_callback(RegisterCallBackFun, RegisterName, Handle),
+                    ok = maybe_do_callback(RegisterCallBackFun, RegisterRef, Handle),
                     {ok, update_this_peer(MkState(Handle))}
             end;
         [{_, Handle}] ->
             %% we already got a handle in ETS
+            ok = maybe_do_callback(RegisterCallBackFun, RegisterRef, Handle),
             {ok, update_this_peer(MkState(Handle))}
     end.
 

--- a/src/libp2p_peerbook.erl
+++ b/src/libp2p_peerbook.erl
@@ -644,7 +644,7 @@ delete_peer(ID, #peerbook{store=Store}) ->
 %% if a peer has been prevalidated then we skip the verify
 %% and trust the caller has verified the signature
 -spec peer_valid(libp2p_peer:peer(), boolean())-> boolean().
-peer_valid(Peer, false = _PreValidated)->
+peer_valid(Peer, PreValidated) when PreValidated == false->
     libp2p_peer:verify(Peer);
-peer_valid(_Peer, true = _PreValidated)->
+peer_valid(_Peer, _PreValidated)->
     true.

--- a/src/libp2p_peerbook.erl
+++ b/src/libp2p_peerbook.erl
@@ -46,8 +46,7 @@
           metadata_fun :: fun(() -> #{binary() => binary}),
           metadata = #{} :: map(),
           metadata_ref = undefined :: undefined | reference(),
-          sig_fun :: fun((binary()) -> binary()),
-          swarm_name :: atom()
+          sig_fun :: fun((binary()) -> binary())
         }).
 
 %%
@@ -99,8 +98,8 @@ put(Handle=#peerbook{pubkey_bin=ThisPeerId}, NewPeer) ->
                 andalso peer_allowable(Handle, NewPeer)
                 of
                 true ->
-                    IsSimilar = libp2p_peer:is_similar(NewPeer, ExistingPeer),
-                    PutValid(NewPeerId, NewPeer, IsSimilar);
+                    _IsSimilar = libp2p_peer:is_similar(NewPeer, ExistingPeer),
+                    PutValid(NewPeerId, NewPeer, false);
                 false ->
                     {error, invalid}
             end
@@ -529,11 +528,11 @@ update_this_peer(State0=#state{}) ->
         {ok, _OldPeer} ->
             case mk_this_peer(State0) of
                 {{ok, NewPeer}, State} ->
-                    %case libp2p_peer:is_similar(NewPeer, OldPeer) of
-                    %    true -> State;
-                    %    false ->
-                        update_this_peer({ok, NewPeer}, get_async_signed_metadata(State));
-                    %end;
+%%                    case libp2p_peer:is_similar(NewPeer, OldPeer) of
+%%                        true -> State;
+%%                        false ->
+                            update_this_peer({ok, NewPeer}, get_async_signed_metadata(State));
+%%                    end;
                 {{error, _Error}, State} ->
                     State
             end

--- a/src/libp2p_peerbook.erl
+++ b/src/libp2p_peerbook.erl
@@ -476,7 +476,7 @@ terminate(_Reason, State=#state{peerbook=#peerbook{tid = TID}}) ->
 -spec maybe_do_callback(function(), atom, peerbook()) -> ok.
 maybe_do_callback(Fun, RegisterName, Handle)->
     case is_function(Fun) of
-        true -> Fun(RegisterName, Handle);
+        true -> Fun(RegisterName, Handle), ok;
         false -> ok
     end.
 
@@ -536,13 +536,11 @@ update_this_peer(Result, State=#state{peer_timer=PeerTimer}) ->
 
 -spec handle_changed_peers(change_descriptor(), #state{}) -> #state{}.
 handle_changed_peers({add, ChangeAdd}, State=#state{notify_peers={{add, Add}, {remove, Remove}}}) ->
-    lager:debug("handling changed peers",[]),
     %% Handle new entries and remove any "removed" entries that are now in the add map
     NewAdd = maps:merge(Add, ChangeAdd),
     NewRemove = lists:filter(fun(Entry) -> maps:is_key(Entry, NewAdd) end, Remove),
     State#state{notify_peers={{add,  NewAdd}, {remove, NewRemove}}};
 handle_changed_peers({remove, ChangeRemove}, State=#state{notify_peers={{add, Add}, {remove, Remove}}}) ->
-    lager:debug("handling changed peers",[]),
     NewAdd = maps:without(ChangeRemove, Add),
     NewRemove = lists:merge(lists:sort(ChangeRemove), Remove),
     State#state{notify_peers={{add,  NewAdd}, {remove, NewRemove}}}.

--- a/test/peerbook_SUITE.erl
+++ b/test/peerbook_SUITE.erl
@@ -142,9 +142,7 @@ session_test(Config) ->
     %% confirm it's cleared
     ?assertAsync({ok, Peer} = libp2p_peerbook:get(Handle, PubKeyBin),
                  [] == libp2p_peer:connected_peers(Peer)),
-
     ok.
-
 
 get_put_test(Config) ->
     Handle = ?config(peerbook, Config),
@@ -156,6 +154,8 @@ get_put_test(Config) ->
     %% Add a peer beyond the self peer
     {ok, NewPeer} = mk_peer(#{}),
     ok = libp2p_peerbook:put(Handle, NewPeer),
+
+    {ok, NewPeer} = libp2p_peerbook:get(Handle, libp2p_peer:pubkey_bin(NewPeer)),
 
     %% Check is_key for self adnd new peer
     ?assert(libp2p_peerbook:is_key(Handle, PubKeyBin)),

--- a/test/peerbook_SUITE.erl
+++ b/test/peerbook_SUITE.erl
@@ -8,7 +8,7 @@
 all() ->
     [
      listen_addr_test,
-     session_test,
+     %%session_test,    test disabled as sessions are no longer to be managed here, TODO - finalise requirements here
      nat_type_test,
      get_put_test,
      blacklist_test,


### PR DESCRIPTION
Includes changes required to incorporate the standalone peerbook into erlang-libp2p
Associated erlang-libp2p PR: https://github.com/helium/erlang-libp2p/pull/265
